### PR TITLE
Fix code scanning alert no. 23: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/WebGoat/Web.config
+++ b/WebGoat/Web.config
@@ -40,7 +40,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
     <httpRuntime enableHeaderChecking="false"/>
     <!-- this is how you would set secure and http only on session cookies -->
     <httpCookies httpOnlyCookies="false" requireSSL="false"/>
-    <compilation defaultLanguage="C#" debug="true" targetFramework="4.8">
+    <compilation defaultLanguage="C#" debug="false" targetFramework="4.8">
       <assemblies>
         <!--add assembly="System.Web.Mobile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" /-->
         <add assembly="Mono.Data.Sqlite"/>


### PR DESCRIPTION
Fixes [https://github.com/michael-freidgeim-webjet/ghas-demo-csharp/security/code-scanning/23](https://github.com/michael-freidgeim-webjet/ghas-demo-csharp/security/code-scanning/23)

To fix the problem, we need to set the `debug` flag to `false` in the `Web.config` file. This change will ensure that the application does not expose sensitive debugging information and will improve performance by disabling debugging features. The change should be made specifically on line 43 of the `Web.config` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
