### PR TITLE
Fix code scanning alert no. 28: SQL query built from user-controlled sources

### DIFF
--- a/WebGoat/App_Code/DB/SqliteDbProvider.cs
+++ b/WebGoat/App_Code/DB/SqliteDbProvider.cs
@@ -286,7 +286,7 @@ namespace OWASP.WebGoat.NET.App_Code.DB
 
         public string UpdateCustomerPassword(int customerNumber, string password)
         {
-            string sql = "update CustomerLogin set password = '" + Encoder.Encode(password) + "' where customerNumber = " + customerNumber;
+            string sql = "update CustomerLogin set password = @password where customerNumber = @customerNumber";
             string output = null;
             try
             {
@@ -296,6 +296,8 @@ namespace OWASP.WebGoat.NET.App_Code.DB
                     connection.Open();
 
                     SqliteCommand command = new SqliteCommand(sql, connection);
+                    command.Parameters.AddWithValue("@password", Encoder.Encode(password));
+                    command.Parameters.AddWithValue("@customerNumber", customerNumber);
                 
                     int rows_added = command.ExecuteNonQuery();
                     


### PR DESCRIPTION
Fixes [https://github.com/michael-freidgeim-webjet/ghas-demo-csharp/security/code-scanning/28](https://github.com/michael-freidgeim-webjet/ghas-demo-csharp/security/code-scanning/28)

To fix the SQL injection vulnerability, we should use parameterized queries instead of string concatenation to construct SQL queries. This approach ensures that user input is treated as data rather than executable code, preventing SQL injection attacks.

In the `UpdateCustomerPassword` method, we will replace the string concatenation with a parameterized query using `SqliteCommand.Parameters.AddWithValue`. This change will ensure that the user input is properly escaped and handled by the database engine.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
