### PR TITLE
Fix code scanning alert no. 3: Clear text storage of sensitive information

### DIFF
--- a/WebGoat/App_Code/ConfigFile.cs
+++ b/WebGoat/App_Code/ConfigFile.cs
@@ -16,6 +16,16 @@ namespace OWASP.WebGoat.NET.App_Code
             
         private const char SPLIT_CHAR = '=';
         
+        private string Protect(string value, string purpose)
+        {
+            return Convert.ToBase64String(MachineKey.Protect(Encoding.UTF8.GetBytes(value), purpose));
+        }
+        
+        private string Unprotect(string value, string purpose)
+        {
+            return Encoding.UTF8.GetString(MachineKey.Unprotect(Convert.FromBase64String(value), purpose));
+        }
+        
         public ConfigFile(string fileName)
         {
             _filePath = fileName;
@@ -88,13 +98,23 @@ namespace OWASP.WebGoat.NET.App_Code
             key = key.ToLower();
             
             if (_settings.ContainsKey(key))
-                return _settings[key];
-                    
+            {
+                string value = _settings[key];
+                if (key == DbConstants.KEY_PWD.ToLower())
+                {
+                    value = Unprotect(value, "Password");
+                }
+                return value;
+            }
             return string.Empty;
         }
             
         public void Set(string key, string value)
         {
+            if (key.ToLower() == DbConstants.KEY_PWD.ToLower())
+            {
+                value = Protect(value, "Password");
+            }
             _settings[key.ToLower()] = value;
         }
 

--- a/WebGoat/dbtest.aspx.cs
+++ b/WebGoat/dbtest.aspx.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Configuration;
 using OWASP.WebGoat.NET.App_Code.DB;
 using OWASP.WebGoat.NET.App_Code;
+using System.Web.Security;
 
 namespace OWASP.WebGoat.NET
 {


### PR DESCRIPTION
Fixes [https://github.com/michael-freidgeim-webjet/ghas-demo-csharp/security/code-scanning/3](https://github.com/michael-freidgeim-webjet/ghas-demo-csharp/security/code-scanning/3)

To fix the problem, we need to ensure that sensitive information is encrypted before being stored and decrypted when it is read. We can use the `System.Web.Security.MachineKey` class to protect and unprotect the data. This will involve modifying the `Set` and `Get` methods in the `ConfigFile` class to handle encryption and decryption, respectively.

1. Modify the `Set` method to encrypt the value before storing it in the `_settings` dictionary.
2. Modify the `Get` method to decrypt the value before returning it.
3. Add helper methods `Protect` and `Unprotect` to handle the encryption and decryption using `MachineKey`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
